### PR TITLE
remove terminal * symbols from fasta files

### DIFF
--- a/profasta/io.py
+++ b/profasta/io.py
@@ -60,7 +60,7 @@ def parse_fasta(file_object: IO[str]) -> Generator[FastaRecord, None, None]:
     for block in fasta_text.split("\n>")[1:]:
         lines = block.split("\n")
         header = lines[0].strip()
-        sequence = "".join(lines[1:]).replace(" ", "")
+        sequence = ("".join(lines[1:]).replace(" ", "").rstrip("*")).upper()
         yield FastaRecord(header, sequence)
 
 


### PR DESCRIPTION
…… and capitalize letters in fasta seq at import time.

I think a separate sequence parser/validator would be prudent, but this should work as an ad hoc solution for the most common issues